### PR TITLE
add country to proof of residence

### DIFF
--- a/examples/proofOfResidence/v6/proofOfResidence.json
+++ b/examples/proofOfResidence/v6/proofOfResidence.json
@@ -90,6 +90,11 @@
           "description": "The ID of the journey that this credential is associated with",
           "type": "string"
         },
+        "country": {
+          "title": "Country",
+          "description": "The country of residence",
+          "type": "string"
+        },
         "base64": {
           "title": "Base64",
           "description": "Base64 encoded image of the proof of residence",
@@ -110,6 +115,7 @@
       "required": [
         "id",
         "journeyId",
+        "country",
         "base64",
         "name",
         "documentType"

--- a/examples/proofOfResidence/v6/proofOfResidence.jsonld
+++ b/examples/proofOfResidence/v6/proofOfResidence.jsonld
@@ -19,6 +19,10 @@
             "@id": "vocab:journeyId",
             "@type": "xsd:string"
           },
+          "country": {
+            "@id": "vocab:country",
+            "@type": "xsd:string"
+          },
           "base64": {
             "@id": "vocab:base64",
             "@type": "xsd:string"

--- a/examples/proofOfResidence/v6/proofOfResidence.md
+++ b/examples/proofOfResidence/v6/proofOfResidence.md
@@ -8,6 +8,12 @@ Unique identifier of the journey which the proof of residence is associated with
 
 `17101e7c-d0d5-494c-a2ac-e2530261930f`
 
+# country
+
+Country of residence.
+
+`DEU`
+
 # base64
 
 Base64 encoded image of the proof of residence.


### PR DESCRIPTION
The information provided by the user in the field shoould also be recorded in the Proof of residence VC along with the image

https://allianceblockprotocol.atlassian.net/browse/NEXID-1041